### PR TITLE
Remove the in-production module

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
   },
   "dependencies": {
     "http-status": "^1.0.1",
-    "in-production": "^1.0.1",
     "statuses": "^1.3.1",
     "lodash": "latest"
   }

--- a/src/in-production.js
+++ b/src/in-production.js
@@ -1,0 +1,1 @@
+module.exports = process.env.NODE_ENV === 'production';

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 import httpStatus from 'http-status';
-import inProduction from 'in-production';
 import statuses from 'statuses';
 import _ from 'lodash';
 
+const inProduction = process.env.NODE_ENV === 'production';
 export default function ({log} = {}) {
   return (err, req, res, next) => { // eslint-disable-line no-unused-vars
     let status = err.status || err.statusCode || httpStatus.INTERNAL_SERVER_ERROR;

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 import httpStatus from 'http-status';
+import inProduction from './in-production';
 import statuses from 'statuses';
 import _ from 'lodash';
 
-const inProduction = process.env.NODE_ENV === 'production';
 export default function ({log} = {}) {
   return (err, req, res, next) => { // eslint-disable-line no-unused-vars
     let status = err.status || err.statusCode || httpStatus.INTERNAL_SERVER_ERROR;

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -100,7 +100,7 @@ describe('express-json-error-handler', () => {
     it('should ignore stack on production', function () {
       this.timeout(5000);
 
-      mockery.registerMock('in-production', true);
+      mockery.registerMock('./in-production', true);
 
       mockery.enable({
         useCleanCache: true,


### PR DESCRIPTION
Remove the in-production module, which needs envify, which calls jstransform, which uses base62 which tries to talk to google analytics which breaks in some environments.

```
├─┬ express-json-error-handler@1.0.0
│ ├── http-status@0.2.5
│ ├─┬ in-production@1.0.1
│ │ └─┬ envify@3.4.1
│ │   ├─┬ jstransform@11.0.3
│ │   │ ├── base62@1.2.7
│ │   │ ├─┬ commoner@0.10.8
│ │   │ │ ├── commander@2.14.1 deduped
│ │   │ │ ├─┬ detective@4.7.1
│ │   │ │ │ ├── acorn@5.5.0 deduped
│ │   │ │ │ └── defined@1.0.0 deduped
│ │   │ │ ├─┬ glob@5.0.15
│ │   │ │ │ ├── inflight@1.0.6 deduped
│ │   │ │ │ ├── inherits@2.0.3 deduped
│ │   │ │ │ ├── minimatch@3.0.4 deduped
│ │   │ │ │ ├── once@1.4.0 deduped
│ │   │ │ │ └── path-is-absolute@1.0.1 deduped
│ │   │ │ ├── graceful-fs@4.1.11 deduped
│ │   │ │ ├── iconv-lite@0.4.19 deduped
│ │   │ │ ├── mkdirp@0.5.1 deduped
│ │   │ │ ├── private@0.1.8 deduped
│ │   │ │ ├── q@1.5.1 deduped
│ │   │ │ └── recast@0.11.23 deduped
│ │   │ ├── esprima-fb@15001.1.0-dev-harmony-fb
│ │   │ ├── object-assign@2.1.1
│ │   │ └─┬ source-map@0.4.4
│ │   │   └── amdefine@1.0.1 deduped
│ │   └── through@2.3.8 deduped
│ ├── lodash@4.17.5
│ └── statuses@1.4.0
```

https://github.com/andrew/base62.js/issues/66